### PR TITLE
Guarantee that the build process runs in order

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,6 +17,7 @@ jobs:
       - run: npm install
       - run: npm run linter:check
       - run: npm run release:test
+      - run: node build.js '0.0.1'
 
       - save_cache:
           paths:

--- a/build.js
+++ b/build.js
@@ -1,22 +1,26 @@
 /* eslint no-console: 0 */
-const { exec } = require('child_process');
+const util = require('util');
+const exec = util.promisify(require('child_process').exec);
 
-const version = process.argv[2];
-
-console.log(`Running build process for vivy-components ${version}`);
-
-const build = 'npm run build:storybook && npm run build:package';
-exec(build, (err, stdout) => {
-  if (err) {
-    throw new Error(`Build command failed: ${err}`);
+async function runCommand(command) {
+  try {
+    const { stdout, stderr } = await exec(command);
+    console.log(`Command completed: ${stdout}`);
+    console.log(stderr);
+  } catch (err) {
+    throw new Error(`Command failed: ${err}`);
   }
-  console.log(`Build successful: ${stdout}`);
-});
+}
 
-const archive = `cp package.json ./dist/build && cd dist/ && tar -zcvf vivy-components-${version}.tar.gz build/`;
-exec(archive, (err, stdout) => {
-  if (err) {
-    throw new Error(`Archive command failed: ${err}`);
-  }
-  console.log(`Archive command successful: ${stdout}`);
-});
+async function runBuildProcess() {
+  const version = process.argv[2];
+
+  console.log(`Running build process for vivy-components ${version}`);
+
+  const build = 'npm run build:storybook && npm run build:package';
+  const archive = `cp package.json ./dist/build && cd dist/ && tar -zcvf vivy-components-${version}.tar.gz build/`;
+  await runCommand(build);
+  await runCommand(archive);
+}
+
+runBuildProcess();

--- a/build.js
+++ b/build.js
@@ -5,10 +5,10 @@ const exec = util.promisify(require('child_process').exec);
 async function runCommand(command) {
   try {
     const { stdout, stderr } = await exec(command);
-    console.log(`Command completed: ${stdout}`);
+    console.log(`Command "${command}" completed. Output:\n${stdout}`);
     console.log(stderr);
   } catch (err) {
-    throw new Error(`Command failed: ${err}`);
+    throw Error(err);
   }
 }
 

--- a/build.js
+++ b/build.js
@@ -12,7 +12,7 @@ async function runCommand(command) {
   }
 }
 
-async function runBuildProcess() {
+(async function runBuildProcess() {
   const version = process.argv[2];
 
   console.log(`Running build process for vivy-components ${version}`);
@@ -21,6 +21,4 @@ async function runBuildProcess() {
   const archive = `cp package.json ./dist/build && cd dist/ && tar -zcvf vivy-components-${version}.tar.gz build/`;
   await runCommand(build);
   await runCommand(archive);
-}
-
-runBuildProcess();
+})();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vivy-components",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "private": true,
   "scripts": {
     "linter:format":


### PR DESCRIPTION
- Add a test step for the build script to fail CI
- Make the build.js script run with async but guarantee that it builds before archiving. With exec running normally both commands run at the same time - causing archiving to finish before building completed.