### PR TITLE
Removes gh-pages from ignore

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,7 +58,6 @@ workflows:
             branches:
               ignore:
                 - master
-                - gh-pages
       - release:
           filters:
             tags:


### PR DESCRIPTION
Fixes CIRCLECI build that always fails.
Example of build: https://circleci.com/gh/UvitaTeam/vivy-components/348