### PR TITLE
MAIN - adds autocomplete to form

### DIFF
--- a/src/InputMasked/InputMasked.jsx
+++ b/src/InputMasked/InputMasked.jsx
@@ -18,7 +18,8 @@ export default function InputMasked({
   mask,
   maskChar,
   validateOnChange,
-  validateOnBlur
+  validateOnBlur,
+  autoComplete
 }) {
   const basic = classNames(["masked-input", true], ["icon-padding", iconName]);
 
@@ -43,6 +44,7 @@ export default function InputMasked({
           >
             {inherited => (
               <input
+                autoComplete={autoComplete ? "on" : "off"}
                 id={id}
                 name={name}
                 type={type}
@@ -71,6 +73,7 @@ InputMasked.propTypes = {
   maskChar: PropTypes.string,
   validateOnChange: PropTypes.bool,
   validateOnBlur: PropTypes.bool,
+  autoComplete: PropTypes.bool,
   rel: PropTypes.shape({})
 };
 
@@ -85,5 +88,6 @@ InputMasked.defaultProps = {
   maskChar: "",
   validateOnChange: true,
   validateOnBlur: true,
+  autoComplete: false,
   rel: React.createRef()
 };


### PR DESCRIPTION
👋 and ☮️ John! 

#### Motivation
Some time ago we talked about having the component `InputMasked` without `autocomplete` function.
This PR will make this come true. 

#### Why is default `false`?
I added the `autoComplete` property which is set by default to `false`, since we use this component only in one place, and in that place we want the functionality of `autoComplete` to be turned off I thought this is the best default value to go with. Please feel free to disagree with me. 

#### Extras
Here is [some react documentation](https://reactjs.org/docs/dom-elements.html#all-supported-html-attributes) that will explain why `autoComplete` and not `autocomplete` (difference in  **C**).