### PR TITLE
MAIN - Removes outliner in an accessible way

### DIFF
--- a/src/Buttons/button.style.js
+++ b/src/Buttons/button.style.js
@@ -32,8 +32,11 @@ const ButtonStyles = styled.div`
     border-radius: 4px;
     display: block;
     text-decoration: none;
-    outline: none;
     cursor: pointer;
+  }
+
+  button:focus:active {
+    outline: 0;
   }
 
   a {

--- a/src/Buttons/button.style.js
+++ b/src/Buttons/button.style.js
@@ -35,16 +35,17 @@ const ButtonStyles = styled.div`
     cursor: pointer;
   }
 
-  button:focus:active {
-    outline: 0;
-  }
-
   a {
     font-family: system-ui;
     border-radius: 4px;
     display: inline-block;
     text-align: center;
     text-decoration: none;
+  }
+
+  a:focus:active,
+  button:focus:active {
+    outline: 0;
   }
 
   .primary .component-child {


### PR DESCRIPTION
♿️ since we want to be health care cool startup who care about all the users, I thought of improving some accessibility on our `a`nchors and `button`s.

#### Motivations
How things are at the moment is that there is no `outline` on the button when you navigate using tabs.
I think that is not what out product should be like. 
I have found a solution that will show the `outline` only when user is navigating with tabs and not when actually clicking the button. Little bit as everybody else does it. 

To rephrase, the final result will be that the outliner is there when you navigate through your tabs and will not be there when you click the button unless the focus wont go anywhere else and stay in the button. 

If the above is not super clear I would be happy to explain in person. :) 

Please have a look and let me know. 🌈 