### PR TITLE
MAIN - adds esc event listener on modal

### DIFF
--- a/src/Modal/Modal.jsx
+++ b/src/Modal/Modal.jsx
@@ -14,10 +14,13 @@ import {
 } from "./modal.style";
 import { Row, Col, Icon, Button } from "../index";
 
+const ESC_KEY = 27;
+
 class Modal extends Component {
   constructor(props) {
     super(props);
     this.closeButton = React.createRef();
+    this.handleEscKeyPress = this.handleEscKeyPress.bind(this);
   }
 
   componentDidMount() {
@@ -25,10 +28,19 @@ class Modal extends Component {
       this.closeButton.current.focus();
     }
     disableBodyScroll(document.querySelector("body"));
+    document.addEventListener("keydown", this.handleEscKeyPress, false);
   }
 
   componentWillUnmount() {
     enableBodyScroll(document.querySelector("body"));
+    document.removeEventListener("keydown", this.handleEscKeyPress, false);
+  }
+
+  handleEscKeyPress({ which: keyPressed }) {
+    if (keyPressed === ESC_KEY) {
+      const { onClose } = this.props;
+      onClose();
+    }
   }
 
   render() {


### PR DESCRIPTION
hello 🌻 @VivyTeam/web , 

one other accessibility 'feature' that a modal is required to have is 
* on key press Escape: Dismisses the Modal if it is visible. 

This PR tackles this down by adding an event listener while the component is mounted in the DOM.
