### PR TITLE
MAIN - Inputs should use tt norms font

### DIFF
--- a/src/Fonts/fonts.style.js
+++ b/src/Fonts/fonts.style.js
@@ -35,7 +35,7 @@ import vivyIconsTtf from "../../public/fonts/vivy-icons/vivy-icons.ttf";
 import vivyIconsSvg from "../../public/fonts/vivy-icons/vivy-icons.svg";
 
 const Fonts = createGlobalStyle`
-    body, input {
+    body, input, textarea {
       font-family: 'Norms', sans-serif;
     }
 

--- a/src/Fonts/fonts.style.js
+++ b/src/Fonts/fonts.style.js
@@ -35,7 +35,7 @@ import vivyIconsTtf from "../../public/fonts/vivy-icons/vivy-icons.ttf";
 import vivyIconsSvg from "../../public/fonts/vivy-icons/vivy-icons.svg";
 
 const Fonts = createGlobalStyle`
-    body {
+    body, input {
       font-family: 'Norms', sans-serif;
     }
 


### PR DESCRIPTION
Inputs do not inherit the font from their parent elements, so we need to manually set it. 

This issue was discovered by one of our designers during a design QA. 

👍 