### PR TITLE
MAIN - Do not scroll overflow content

### DIFF
--- a/src/Table/table.styles.js
+++ b/src/Table/table.styles.js
@@ -41,6 +41,11 @@ export const StyledTable = styled(WithoutConflictingDefaultStyles)`
   && {
     border: unset;
   }
+  && {
+    .rt-table {
+      overflow: visible;
+    }
+  }
 
   .rt-table {
     .rt-thead {


### PR DESCRIPTION
Currently:
When a table is long enough it will scroll on safari and some chrome versions. 

Wanted:
This behaviour is inconsistent (even between the same versions of chrome) as such this PR makes no scrolling the sensible default. 

Lets talk about this in person.

