### PR TITLE
MAIN - Do not show text behind the eye

### DIFF
--- a/src/InputPassword/inputPassword.style.js
+++ b/src/InputPassword/inputPassword.style.js
@@ -24,6 +24,10 @@ const InputPasswordStyles = styled.div`
       font-size: 24px;
     }
   }
+
+  input {
+    margin-right: 54px;
+  }
 `;
 
 export default InputPasswordStyles;

--- a/src/InputWrapper/InputWrapper.jsx
+++ b/src/InputWrapper/InputWrapper.jsx
@@ -27,7 +27,7 @@ export default function InputWrapper({
             <Icon name={iconName} />
           </div>
         ) : null}
-        {children}
+        <div className="input-border">{children}</div>
         {error ? <span className="error-feedback">{error}</span> : null}
       </label>
     </Styles>

--- a/src/InputWrapper/inputWrapper.style.js
+++ b/src/InputWrapper/inputWrapper.style.js
@@ -20,11 +20,29 @@ const InputStyles = styled.div`
     }
   }
 
+  .input-border {
+    display: flex;
+    flex-direction: column;
+    border-radius: 4px;
+    border: solid 1px #cdcdcd;
+    background-color: #ffffff;
+
+    &:hover {
+      border-color: #04d4bf;
+      transition: border-color 0.2s ease;
+    }
+
+    &:focus-within {
+      box-shadow: 0 0 0 2px rgba(4, 212, 191, 0.2);
+      border-color: #04d4bf;
+      transition: border-color 0.2s ease, box-shadow 0.2s ease;
+    }
+  }
+
   input {
     height: 48px;
-    border-radius: 4px;
-    background-color: #ffffff;
-    border: solid 1px #cdcdcd;
+    background-color: transparent;
+    border: none;
     font-size: 18px;
     font-weight: normal;
     color: #353f41;
@@ -43,16 +61,8 @@ const InputStyles = styled.div`
       padding: 2px 16px 2px 54px;
     }
 
-    &:hover {
-      border-color: #04d4bf;
-      transition: border-color 0.2s ease;
-    }
-
     &:focus {
       outline: none;
-      box-shadow: 0 0 0 2px rgba(4, 212, 191, 0.2);
-      border-color: #04d4bf;
-      transition: border-color 0.2s ease, box-shadow 0.2s ease;
     }
 
     &::placeholder {


### PR DESCRIPTION
👋 

G'day!

This PR fixes two issues:
- Text going behind the eye icon in the password input
- Dashlane icon overlapping the eye icon.

It turns out that the dashlane eye is always attached to the `input` element itself, so this means when we want to offset the content with the button, we should instead draw the input border on the above element. So this PR changes the input wrapper so that the parent element (containing everything like the input, eye icon etc) is the one with the border (instead of the input) and then makes the input width the correct logical size (shorter). 

@paschalidi 🎈 

The dashlane icon is still a little bit overlapped by the text, but I dont think we should change our padding size in the design to compensate for some 3rd party browser plug.

Pics:
![image](https://user-images.githubusercontent.com/492636/59510560-4b4b6300-8eb4-11e9-96a5-d7e703f3dc56.png)
