### PR TITLE
MAIN - removes the `panel`

### DIFF
--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -9,6 +9,7 @@ addDecorator(withGlobalStyles);
 
 addParameters({
   options: {
+    showPanel: false,
     name: "Vivy",
     theme: create({
       base: "light",


### PR DESCRIPTION
Heya @Weetbix , 

a little "improvement" on the way that storybook shows the content. 

Currently we have this Panel on the bottom of each story that shows in the end nothing. 
![image](https://user-images.githubusercontent.com/4181674/59869130-e9e33280-9392-11e9-8f94-1a4565e30e7b.png)

This PR removes that.