### PR TITLE
MAIN - removes min-width

### DIFF
--- a/src/Modal/modal.style.js
+++ b/src/Modal/modal.style.js
@@ -50,7 +50,6 @@ export const Content = styled.div`
   background: ${Colors.white};
   padding: 16px 16px 24px 16px;
   border-radius: 8px;
-  min-width: 320px; /* This just a default width */
   max-width: 920px;
 `;
 


### PR DESCRIPTION
Hey 👋 

there is a little bug on the modal styling and this PR fixes it :D 

### What is the bug? 
for devices with width <= 320px the modal is not being shown correctly. 
### Screenshot of the bug
![image](https://user-images.githubusercontent.com/4181674/60812235-55017700-a191-11e9-8301-5babf6cca1be.png)

### Screenshot of the fixed Modal :tada:
![image](https://user-images.githubusercontent.com/4181674/60812407-b4f81d80-a191-11e9-8859-546f2069f251.png)


 