### PR TITLE
MAIN - sm size works for mobiles

### DIFF
--- a/src/Modal/Modal.jsx
+++ b/src/Modal/Modal.jsx
@@ -69,7 +69,7 @@ class Modal extends Component {
           <Overlay onClick={onClose} />
           <Height>
             <Row position="center" verticalAlign="middle">
-              <Col lg={size === "sm" ? 7 : 12}>
+              <Col lg={size === "sm" ? 7 : 12} sm={12}>
                 <Content>
                   <Row textAlign="right" position="end">
                     <Col lg={1}>


### PR DESCRIPTION
heya @Weetbix 👋 

there is a small bug on the modal for the mobile devices. 


On the mobile devices the width of the modal should be 100 percent of the screen. 

This PR tackles that. 
 
### Screenshot before the fix 
![image](https://user-images.githubusercontent.com/4181674/61212822-99e25c00-a703-11e9-800e-40e47abade67.png)
### Screenshot after the fix
![image](https://user-images.githubusercontent.com/4181674/61214321-ee87d600-a707-11e9-9d54-c3458e2ab0b9.png)
