### PR TITLE
MAIN - fixes ios scroll bug

### DIFF
--- a/src/Modal/Modal.jsx
+++ b/src/Modal/Modal.jsx
@@ -27,12 +27,12 @@ class Modal extends Component {
     if (this.closeButton.current) {
       this.closeButton.current.focus();
     }
-    disableBodyScroll(document.querySelector("body"));
+    disableBodyScroll(document.querySelector("#modal-body-area"));
     document.addEventListener("keydown", this.handleEscKeyPress, false);
   }
 
   componentWillUnmount() {
-    enableBodyScroll(document.querySelector("body"));
+    enableBodyScroll(document.querySelector("#modal-body-area"));
     document.removeEventListener("keydown", this.handleEscKeyPress, false);
   }
 
@@ -83,7 +83,7 @@ class Modal extends Component {
                     </Col>
                   </Row>
 
-                  <BodyArea>{children}</BodyArea>
+                  <BodyArea id="modal-body-area">{children}</BodyArea>
 
                   <ButtonsArea>
                     <Row position={size === "sm" ? "center" : "end"}>

--- a/src/Modal/modal.style.js
+++ b/src/Modal/modal.style.js
@@ -65,6 +65,8 @@ const ModalMargin = styled.div`
 export const BodyArea = styled(ModalMargin)`
   @media (max-width: ${xsMax}px) {
     overflow-y: auto;
+    label: scroll-box;
+    -webkit-overflow-scrolling: touch;
     max-height: 75vh;
   }
 `;


### PR DESCRIPTION
Heya @Weetbix, 

QA found an interesting bug where on iOS the modal of the body wont scroll. 
Looks like the documentation was not clear about `disableBodyScroll` and this caused an issue to some other pps as well. More info, [here](https://github.com/willmcpo/body-scroll-lock/issues/102). 

https://github.com/willmcpo/body-scroll-lock#why-bsl
Documentation is now updated and mentions that you need to specify explicitly the area that you would like to have scrollable, whereas we had it the other way around we used to specify the body.. 

On the styles 
```
    label: scroll-box;
    -webkit-overflow-scrolling: touch;
```
Is added in order to have native scrolling behaviour on iOS, when one of those is missing on iOS you cant see the scrollbar, I lean towards giving the users the ability to see where stand while scrolling.

Take a look please