### PR TITLE
[ESB-165] Change index import to avoid loading of not migrated components

### DIFF
--- a/src/Checkbox/checkbox.style.ts
+++ b/src/Checkbox/checkbox.style.ts
@@ -1,5 +1,5 @@
 import styled from "styled-components";
-import { Colors } from "..";
+import Colors from "../Colors";
 import mapping from "../../public/fonts/vivy-icons/iconMapping.json";
 
 const checkboxEmpty = mapping["icon-checkbox-empty"];


### PR DESCRIPTION
**Jira ticket:** https://uvitadev.atlassian.net/browse/EBS-165

## What is this PR about?

Follow up fix for https://github.com/VivyTeam/vivy-components/pull/682 
When importing the migrated component into the portal codebase import errors occurred because of a universal import within the style definitions.

## What has changed?

- [x] Change import source from index to component file

## Visual changes

No visual changes